### PR TITLE
[FIX]: Overlapping error feedback with label in login and signup form

### DIFF
--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -64,7 +64,7 @@ const Login = () => {
               <Card className="bg-secondary shadow border-0">
                 <Card.Body className="px-lg-5 py-lg-5">
                   <Form onSubmit={formik.handleSubmit}>
-                    <Form.Group className="mb-3 position-relative" >
+                    <Form.Group className="position-relative" >
                       <Form.Label id="1">Email</Form.Label>
                       <Form.Control
                         name="email"
@@ -73,13 +73,14 @@ const Login = () => {
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                         isInvalid={formik.errors.email}
+                        className={formik.errors.email?"mb-5":"mb-3"}
                         ref={email}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
                         {formik.errors.email}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group className="mb-3 position-relative">
+                    <Form.Group className="position-relative">
                       <Form.Label id="2">Password</Form.Label>
                       <Form.Control
                         name="password"
@@ -88,13 +89,14 @@ const Login = () => {
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                         isInvalid={formik.errors.password}
+                        className={formik.errors.password?"mb-5":"mb-4"}
                         ref={password}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
                         {formik.errors.password}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group className="mb-3 mt-5">
+                    <Form.Group className="mb-3">
                       <Form.Control 
                         style={{color: '#FFFFFF'}}
                         className="bg-blue"

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -72,8 +72,12 @@ const Login = () => {
                         value={formik.values.email}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        isInvalid={formik.errors.email}
-                        className={formik.errors.email?"mb-5":"mb-3"}
+                        isInvalid={
+                          Boolean(formik.touched.email&&formik.errors.email)
+                        }
+                        className={
+                          Boolean(formik.touched.email&&formik.errors.email)?"mb-5":"mb-3"
+                        }
                         ref={email}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
@@ -88,8 +92,12 @@ const Login = () => {
                         value={formik.values.password}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        isInvalid={formik.errors.password}
-                        className={formik.errors.password?"mb-5":"mb-4"}
+                        isInvalid={
+                          Boolean(formik.touched.password&&formik.errors.password)
+                        }
+                        className={
+                          Boolean(formik.touched.password&&formik.errors.password)?"mb-5":"mb-4"
+                        }
                         ref={password}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -68,7 +68,7 @@ const Signup = () => {
               <Card className="bg-secondary shadow border-0">
                 <Card.Body className="px-lg-5 py-lg-5">
                   <Form onSubmit={formik.handleSubmit}>
-                    <Form.Group className="mb-3 position-relative" >
+                    <Form.Group className="position-relative" >
                       <Form.Label id="1">Name</Form.Label>
                       <Form.Control
                         name="name"
@@ -76,13 +76,14 @@ const Signup = () => {
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                         isInvalid={formik.errors.name}
+                        className={formik.errors.name?"mb-5":"mb-4"}
                         ref={name}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
                         {formik.errors.name}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group className="mb-3 position-relative" >
+                    <Form.Group className="position-relative" >
                       <Form.Label id="1">Email</Form.Label>
                       <Form.Control
                         name="email"
@@ -91,13 +92,14 @@ const Signup = () => {
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                         isInvalid={formik.errors.email}
+                        className={formik.errors.email?"mb-5":"mb-4"}
                         ref={email}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
                         {formik.errors.email}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group className="mb-3 position-relative">
+                    <Form.Group className="position-relative">
                       <Form.Label id="2">Password</Form.Label>
                       <Form.Control
                         name="password"
@@ -106,13 +108,14 @@ const Signup = () => {
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
                         isInvalid={formik.errors.password}
+                        className={formik.errors.password?"mb-5":"mb-4"}
                         ref={password}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
                         {formik.errors.password}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group className="mb-3 mt-5">
+                    <Form.Group className="mb-3">
                       <Form.Control 
                         style={{color: '#FFFFFF'}}
                         className="bg-blue"

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -75,8 +75,12 @@ const Signup = () => {
                         value={formik.values.name}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        isInvalid={formik.errors.name}
-                        className={formik.errors.name?"mb-5":"mb-4"}
+                        isInvalid={
+                          Boolean(formik.touched.name&&formik.errors.name)
+                        }
+                        className={
+                          Boolean(formik.touched.name&&formik.errors.name)?"mb-5":"mb-4"
+                        }
                         ref={name}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
@@ -91,8 +95,12 @@ const Signup = () => {
                         value={formik.values.email}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        isInvalid={formik.errors.email}
-                        className={formik.errors.email?"mb-5":"mb-4"}
+                        isInvalid={
+                          Boolean(formik.touched.email&&formik.errors.email)
+                        }
+                        className={
+                          Boolean(formik.touched.email&&formik.errors.email)?"mb-5":"mb-4"
+                        }
                         ref={email}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>
@@ -107,8 +115,12 @@ const Signup = () => {
                         value={formik.values.password}
                         onChange={formik.handleChange}
                         onBlur={formik.handleBlur}
-                        isInvalid={formik.errors.password}
-                        className={formik.errors.password?"mb-5":"mb-4"}
+                        isInvalid={
+                          Boolean(formik.touched.password&&formik.errors.password)
+                        }
+                        className={
+                          Boolean(formik.touched.password&&formik.errors.password)?"mb-5":"mb-4"
+                        }
                         ref={password}
                       />
                       <Form.Control.Feedback type="invalid" tooltip>


### PR DESCRIPTION
Here is the screenshot of the issue
![Dynamic-Portfolio_overlap](https://user-images.githubusercontent.com/56883128/209058723-c2ed59c3-9397-42c5-9a0e-afc9a1037b09.png)

Fixed in both login and signup form
![Dynamic-Portfolio_signUp_afterFix](https://user-images.githubusercontent.com/56883128/209058727-7f574242-08db-4b89-b9a3-d72ee5873b21.png)

[Dynamic-Portfolio_afterFix.webm](https://user-images.githubusercontent.com/56883128/209058675-ec918b28-973c-47b8-9857-81ca9aa4c422.webm)


